### PR TITLE
Examples Update in will-change Article

### DIFF
--- a/articles/_posts/2014-06-10-css-will-change-property.md
+++ b/articles/_posts/2014-06-10-css-will-change-property.md
@@ -178,7 +178,7 @@ The `will-change` property takes one of four possible values: `auto`, `scroll-po
 The `<custom-ident>` value is used to specify the name(s) of one or more properties that you expect to change. Multiple properties are comma-separated. The following are examples of valid `will-change` declarations with specified property names:
 
 	will-change: transform;
-	will-change: transform, opacity
+	will-change: transform, opacity;
 	will-change: top, left, bottom, right;
 
 The `<custom-ident>` value excludes the keywords `will-change`, `none`, `all`, `auto`, `scroll-position`, and `contents`, in addition to the keywords normally excluded from [`<custom-ident>`](http://dev.w3.org/csswg/css-values-3/#identifier-value). So, as we mentioned in the beginning of the article, the `will-change: all` declaration is invalid and will thus be ignored by the browser.


### PR DESCRIPTION
I've updated some of the examples by removing property names that won't be optimized and replacing them with ones that can be. For example, based on some feedback I got from David Baron, and I agree, the `animation` property does not hint the browser which properties will change. Instead, the properties that are going to change in the keyframes block should be used as values for `will-change`. I updated the CSS and JS accordingly. Same applies for `position` property: instead of using `position` which doesn't get any optimizations, I just used `top`, `left`, etc.
