### PR TITLE
Source code amendments required for two use cases.

### DIFF
--- a/articles/_posts/2014-07-22-responsive-images.md
+++ b/articles/_posts/2014-07-22-responsive-images.md
@@ -258,8 +258,7 @@ For browser windows with a width of 1280 CSS pixels and wider, a full-shot photo
 
 	<picture>
 		<source
-			media="(min-width: 640px)"
-			sizes="60vw" 
+			sizes="(min-width: 640px) 60vw, 100vw"
 			srcset="opera-200.webp 200w,
 					opera-400.webp 400w,
 					opera-800.webp 800w,
@@ -375,8 +374,7 @@ For browser windows with a width of 1280 CSS pixels and wider, a full-shot photo
 
 	<picture>
 		<source
-			media="(min-width: 640px)"
-			sizes="60vw"
+			sizes="(min-width: 640px) 60vw, 100vw"
 			srcset="opera-200.webp 200w,
 					opera-400.webp 400w,
 					opera-800.webp 800w,


### PR DESCRIPTION
The two use cases with anomalies are:
    1) Changing image sizes & different image types use case
    2) Changing image sizes, high-DPI images & different image types use case

For these two use cases the <source> tag is currently missing the following two additional attributes: 

```
media="(min-width: 640px)"
sizes="60vw"
```

Currently without these attributes their descriptive text reading... "windows with a width of 640 CSS pixels and wider, a photo with a width of 60% of the viewport width is used"... will only be effective when WebP is not supported.

Surely, these must be required to meet the use case description? Or the use case descriptions require amending.

Interestingly, these are the only two use cases which currently fail in Chrome Canary Version 38.0.2114.2 using the current markup. 
With these additional attributes Chrome Canary passes all use cases.

Cheers, Rob.
