### PR TITLE
Fix link from `.htaccess`

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,7 @@
-# Note: <https://github.com/h5bp/server-configs-apache/blob/master/src/.htaccess>
-# is used on the server as `/var/www/conf/1-h5bp-server-config.conf`. Those
-# settings are only loaded when Apache starts, not once for each request.
+# Note: The configurations provided by the Apache Server Configs project
+# <https://github.com/h5bp/server-configs-apache/> are used on the server
+# as `/var/www/conf/1-h5bp-server-config.conf`. Those settings are only
+# loaded when Apache starts, not once for each request.
 #
 # This file, on the other hand, should only be used for Dev.Opera-specific
 # settings (if any) and rewrite rules.


### PR DESCRIPTION
Link directly to the Apache Server Configs project instead of a specific file from within the repository, as otherwise, the link will be broken every time the file is moved to a new location.
