### PR TITLE
Enable kerning, ligatures, contextual ligatures and contextual alternates

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -7,6 +7,7 @@ body {
 	max-width:1200px;
 	background:#FFF;
 	color:#000;
+	font-feature-settings: "kern", "liga", "clig", "calt";
 	font:16px/1.6 Helvetica, Arial, sans-serif;
 	}
 a {


### PR DESCRIPTION
This globally enables kerning, ligatures, contextual ligatures and contextual alternates. This should improve readability and has no downsides I can think of (most of these features should be enabled by default in Blink/WebKit per the CSS spec, but are not).