### PR TITLE
Add Service Worker

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,7 @@
 	<footer block="footer">
 		<p elem="copy">Copyright © 2006—{{ site.time | date: '%Y' }} Opera Software ASA. Some rights reserved. <a href="https://github.com/operasoftware/devopera/blob/master/CONTRIBUTING.md" elem="link" mod="contribute">Contribute!</a></p>
 	</footer>
+	<script>if('serviceWorker' in navigator){navigator.serviceWorker.register('/service-worker.js')}</script>
 {% if page.categories contains 'articles' or page.categories contains 'tv' or page.categories contains 'blog' %}
 	<script src="/scripts/highlight.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>

--- a/errors/offline.md
+++ b/errors/offline.md
@@ -1,0 +1,6 @@
+---
+title: Offline
+layout: page
+---
+
+We were unable to load the page you requested. Please check your network connection and try again.

--- a/scripts/sw-cache-polyfill.js
+++ b/scripts/sw-cache-polyfill.js
@@ -1,0 +1,85 @@
+// https://github.com/coonsta/cache-polyfill/blob/master/dist/serviceworker-cache-polyfill.js
+
+if (!Cache.prototype.add) {
+	Cache.prototype.add = function add(request) {
+		return this.addAll([request]);
+	};
+}
+
+if (!Cache.prototype.addAll) {
+	Cache.prototype.addAll = function addAll(requests) {
+		var cache = this;
+
+		// Since DOMExceptions are not constructable:
+		function NetworkError(message) {
+			this.name = 'NetworkError';
+			this.code = 19;
+			this.message = message;
+		}
+		NetworkError.prototype = Object.create(Error.prototype);
+
+		return Promise.resolve().then(function() {
+			if (arguments.length < 1) throw new TypeError();
+
+			// Simulate sequence<(Request or USVString)> binding:
+			var sequence = [];
+
+			requests = requests.map(function(request) {
+				if (request instanceof Request) {
+					return request;
+				}
+				else {
+					return String(request); // may throw TypeError
+				}
+			});
+
+			return Promise.all(
+				requests.map(function(request) {
+					if (typeof request === 'string') {
+						request = new Request(request);
+					}
+
+					var scheme = new URL(request.url).protocol;
+
+					if (scheme !== 'http:' && scheme !== 'https:') {
+						throw new NetworkError("Invalid scheme");
+					}
+
+					return fetch(request.clone());
+				})
+			);
+		}).then(function(responses) {
+			// TODO: check that requests don't overwrite one another
+			// (don't think this is possible to polyfill due to opaque responses)
+			return Promise.all(
+				responses.map(function(response, i) {
+					return cache.put(requests[i], response);
+				})
+			);
+		}).then(function() {
+			return undefined;
+		});
+	};
+}
+
+if (!CacheStorage.prototype.match) {
+	// This is probably vulnerable to race conditions (removing caches etc)
+	CacheStorage.prototype.match = function match(request, opts) {
+		var caches = this;
+
+		return this.keys().then(function(cacheNames) {
+			var match;
+
+			return cacheNames.reduce(function(chain, cacheName) {
+				return chain.then(function() {
+					return match || caches.open(cacheName).then(function(cache) {
+						return cache.match(request, opts);
+					}).then(function(response) {
+						match = response;
+						return match;
+					});
+				});
+			}, Promise.resolve());
+		});
+	};
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const OFFLINE_CACHE = 'offline';
+const OFFLINE_URL = '/errors/offline.html';
+
+importScripts('/scripts/sw-cache-polyfill.js');
+
+self.addEventListener('install', function(event) {
+	event.waitUntil(
+		caches.open(OFFLINE_CACHE).then(function(cache) {
+			return cache.addAll([
+				OFFLINE_URL,
+				'/styles/screen.css?v=fresh',
+				'/images/github.svg',
+				'/images/logo.png',
+				'/images/logo@2x.png',
+				'/scripts/highlight.js',
+				'/scripts/salvattore.js'
+			]);
+		})
+	);
+});
+
+self.addEventListener('fetch', function(event) {
+	if (
+		event.request.method == 'GET' &&
+		event.request.headers.get('accept').includes('text/html')
+	) {
+		// It’s a GET request for an HTML document.
+		//console.log('Handling fetch event for', event.request.url);
+		event.respondWith(
+			fetch(event.request).catch(function(exception) {
+				// The `catch` is only triggered if `fetch()` throws an exception,
+				// which most likely happens due to the server being unreachable.
+				console.error(
+					'Fetch failed; returning offline page instead.',
+					exception
+				);
+				return caches.open(OFFLINE_CACHE).then(function(cache) {
+					return cache.match(OFFLINE_URL);
+				});
+			})
+		);
+	} else {
+		event.respondWith(
+			caches.match(event.request).then(function(response) {
+				return response || fetch(event.request);
+			})
+		);
+	}
+
+});


### PR DESCRIPTION
Note that `service-worker.js` must be in the root (i.e. not in the `scripts` directory) as we want it to have access to the whole origin.

Another consequence is that assets (i.e. CSS + JS files + images used from the CSS on every page) must be versioned, i.e. every time they change, they need a new file name and the service worker must be updated accordingly.