### PR TITLE
markdowninline: make capable of using Jekyll 3 OR Jekyll 2

### DIFF
--- a/_plugins/markdownline.rb
+++ b/_plugins/markdownline.rb
@@ -2,7 +2,11 @@ module Jekyll
 	module MarkdownLine
 		def markdownline(input)
 			site = @context.registers[:site]
-			converter = site.getConverterImpl(Jekyll::Converters::Markdown)
+			converter = if site.respond_to?(:find_converter_instance)
+				site.find_converter_instance(Jekyll::Converters::Markdown)
+			else
+				site.getConverterImpl(Jekyll::Converters::Markdown)
+			end
 			converter.convert(input.to_s).gsub(/\<\/?p\>/, '').gsub("\n", '')
 		end
 	end


### PR DESCRIPTION
In Jekyll 3, `Site#getConverterImpl` was renamed to `Site#find_converter_instance`. This change detects whether the latter exists and uses it if it does, falling back to the former in case it doesn't.