### PR TITLE
will-change: update browser support

### DIFF
--- a/articles/_posts/2014-06-10-css-will-change-property.md
+++ b/articles/_posts/2014-06-10-css-will-change-property.md
@@ -192,7 +192,7 @@ As mentioned before, some properties will have no effect when specified in `will
 
 ## Browser Support
 
-At the time of writing of this article, only Chrome Canary 36+, Opera Developer 23+, and Firefox Nightly support the `will-change` property. There is [an intent to ship it to the stable channel](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/LwvyVCMQx1k) too. And word says that it won’t be long before it is supported in all modern browsers.
+As of August 2015, Chrome 36+, Opera 24+, and Firefox 36+ support the `will-change` property. Safari is [currently implementing](https://bugs.webkit.org/show_bug.cgi?id=147772) `will-change` and Edge lists it as ["under consideration"](https://dev.modern.ie/platform/status/csswillchange/?filter=f3e0000bf&search=will-change).
 
 ## Final Words
 


### PR DESCRIPTION
webkit started implementing, so time for a refresher. (i'll go update MDN too)

<hr>

Also, unrelated… but I wanted to tell someone.. here's Chrome's behavior for custom-ident's…

### will-change values that trigger a compositing layer in Chrome:
* opacity
* transform, -webkit-transform
* top, left, bottom, right

[source: `ComputedStyle::hasWillChangeCompositingHint()`](https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/core/style/ComputedStyle.cpp&q=ComputedStyle::hasWillChangeCompositingHint%20f:cpp&sq=package:chromium&type=cs&l=877)

### will-change values that trigger a stacking context in chrome
* opacity
* transform, -webkit-transform
* transform-style, -webkit-transform-style
* perspective, -webkit-perspective
* -webkit-mask, -webkit-mask-box-image, -webkit-clip-path, -webkit-box-reflect, -webkit-filter
* z-index
* position

[source: `hasWillChangeThatCreatesStackingContext`](https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/core/css/resolver/StyleAdjuster.cpp&q=hasWillChangeThatCreatesStackingContext&sq=package:chromium&type=cs&l=129)

### also
* AFAICT, `scroll-position` does nothing in Chrome currently.
* `contents` appears to be a compositing layer hint for whatever children are being changed.