### PR TITLE
Update 2014-03-27-showmodaldialog.md

### DIFF
--- a/blog/_posts/2014-03-27-showmodaldialog.md
+++ b/blog/_posts/2014-03-27-showmodaldialog.md
@@ -58,3 +58,5 @@ Depending on the complexity of your code, switching the codebase over to use `<d
 The latest plan is to land the `showModalDialog` removal in Chromium 37. This means the feature will be gone in Opera 24 and Chrome 37, both of which should be released in September.
 
 Mozilla is [looking to remove `showModalDialog` as well](https://bugzilla.mozilla.org/show_bug.cgi?id=981796), but it’s unsure when this will happen exactly. Probably not before Firefox 32.
+
+Note:  The dialog-polyfill example as noted on GitHub is NOT compatible with IE, as it relies on the 2015 ECMAScript standard construct "Promise", which is not yet supported by IE 11:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise


### PR DESCRIPTION
Added final paragraph
Note:  The dialog-polyfill example as noted on GitHub is NOT compatible with IE, as it relies on the 2016 ECMAScript standard "Promise", which is not a construct supported by IE:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise

When saying that an example is cross-browser, how about actually testing it and including IE?  As much as you guys may hate it, it is what those that live in the land of Microsoft products (i.e. SharePoint) must deal with everyday.  Thanks.