### PR TITLE
Fix links to other TV articles and broken markdown-HTML conversion of TOC list

### DIFF
--- a/src/tv/_posts/2012-09-05-functional-keys-in-opera-tv-browsers.md
+++ b/src/tv/_posts/2012-09-05-functional-keys-in-opera-tv-browsers.md
@@ -7,20 +7,18 @@ license: cc-by-3.0
 ---
 
 <div class="note">
-<p>This article offers advice for generic browsers based on the Opera Device SDK. For specific information about the Opera TV Store – which introduces further functionality, as well as additional requirements to authors – please refer to this separate article: <a href="https://dev.opera.com/articles/view/functional-key-handling-in-opera-tv-store-applications/"><cite>Functional key handling in Opera TV Store applications</cite></a>.</p>
+This article offers advice for generic browsers based on the Opera Device SDK. For specific information about the Opera TV Store – which introduces further functionality, as well as additional requirements to authors – please refer to this separate article: [Functional key handling in Opera TV Store applications](/tv/functional-key-handling-in-opera-tv-store-applications/).
 </div>
 
-<ul class="toc">
-<li><a href="#spatial-functional">Spatial navigation and functional buttons</a></li>
-<li><a href="#handling-keydown">Handling <code>keydown</code> events</a>
-<li><a href="#repeat">Repeating key events</a></li>
-<li><a href="#prevent-default">Preventing default spatial navigation</a></li>
-</ul>
+- [Spatial navigation and functional buttons](#spatial-functional)
+- [Handling `keydown` events](#handling-keydown)
+- [Repeating key events](#repeat)
+- [Preventing default spatial navigation](#prevent-default)
 
 <h2 id="spatial-functional">Spatial navigation and functional buttons</h2>
 
 <p>Browsers based on the Opera Device SDK are generally designed to use the standard four-way directional keys on a remote control for spatial navigation. Opera's spatial navigation works in a similar way to traditional <kbd>TAB</kbd> based keyboard access in most browsers, allowing users to move between focusable elements (links, form controls, image map areas). In addition, spatial navigation also employs heuristics that make arbitrary elements with attached <code>click</code> and <code>mouseover</code> JavaScript events focusable as well. Lastly, as the name implies, spatial navigation in Opera allows the user to move between those elements based on their spatial relationship on screen, rather than in source order (as with <kbd>TAB</kbd> navigation).</p>
-<p>In most cases, websites can simply rely on Opera's spatial navigation to handle site navigation. There are simple mechanisms to further <a href="https://dev.opera.com/articles/view/tweaking-spatial-navigation-for-tv-browsing/">tweak spatial navigation for TV browsing</a> using CSS3.</p>
+<p>In most cases, websites can simply rely on Opera's spatial navigation to handle site navigation. There are simple mechanisms to further [tweak spatial navigation for TV browsing](/tv/tweaking-spatial-navigation-for-tv-browsing/) using CSS3.</p>
 <p>However, for maximum control, web authors may also choose to handle the navigation of their site (or or specific aspects of their site, such as individual image carousel elements for instance) themselves by intercepting key presses from the remote control. This makes it possible to not only react to the basic directional buttons (<kbd>UP</kbd>, <kbd>RIGHT</kbd>, <kbd>DOWN</kbd>, <kbd>LEFT</kbd>), but to further bind functionality to the various shortcut and functional keys (such as <kbd>BACK</kbd>, <kbd>INFO</kbd>, <kbd>OPTIONS</kbd> or the <kbd>RED</kbd> button).</p>
 
 <h2 id="handling-keydown">Handling <code>keydown</code> events</h2>


### PR DESCRIPTION
currently, TOC somehow loses the closing `</ul>`, making the "Spatial navigation..." and everything after it effectively part of the `<ul>` - this causes a left-hand margin
> ![capture](https://cloud.githubusercontent.com/assets/895831/12089354/dd3e2a26-b2db-11e5-8d05-3056b65777dc.PNG)

as well as ugly styling of lists (lack of bottom margin) later on in the article 

> ![capture2](https://cloud.githubusercontent.com/assets/895831/12089356/e021160e-b2db-11e5-875e-108d7b99dbea.PNG)