### PR TITLE
Update fixing-the-scrolltop-bug for flags change

### DIFF
--- a/src/articles/_posts/2015-05-20-fixing-the-scrolltop-bug.md
+++ b/src/articles/_posts/2015-05-20-fixing-the-scrolltop-bug.md
@@ -84,7 +84,7 @@ Problem: This prevents browsers from fixing the bug. We need to fix this!
 ## How do I know if my site is affected?
 
 1. Is your page in quirks mode? Check `document.compatMode` in the console in the browser’s web developer tools. If it says `BackCompat`, you’re not affected (but you [should not use quirks mode](https://hsivonen.fi/doctype/#choosing)!).
-2. Run Chrome or Opera with this setting enabled: `chrome://flags/#scroll-top-left-interop`. This makes Chrome/Opera use `html` as the scrolling element (in standards mode).
+2. Run Chrome or Opera with `chrome://flags/#enable-experimental-web-platform-features` enabled (or more specifically with the `--enable-blink-features=ScrollTopLeftInterop` command line flag). This makes Chrome/Opera use `html` as the scrolling element (in standards mode).
 3. See if your site still works. If something is now broken, possibly your site is using UA sniffing to determine `html` vs `body` for scrolling APIs.
 
 ## Towards a fix: `document.scrollingElement`


### PR DESCRIPTION
`ScrollTopLeftInterop` mode was long ago [promoted](https://src.chromium.org/viewvc/blink?view=revision&revision=200602) to "experimental status".  I just [removed](http://crbug.com/536913) the specific entry in about:flags for it. Update the guidance to reflect this.

/cc @zcorpan 