### PR TITLE
Nitpick: DOMHighResTimeStamp has a resolution of 5 microseconds

### DIFF
--- a/src/blog/_posts/2016-03-15-opera-36.md
+++ b/src/blog/_posts/2016-03-15-opera-36.md
@@ -141,7 +141,7 @@ Additionally, [`FetchEvent.prototype.clientId`](https://slightlyoff.github.io/Se
 
 [`Event.prototype.timeStamp`](https://dom.spec.whatwg.org/#dom-event-timestamp) indicates the time at which a given event took place. Previously, this `timeStamp` value was represented as a `DOMTimeStamp`, which was a whole number of milliseconds since the system epoch.
 
-Starting with Chromium 49, `timeStamp` is a `DOMHighResTimeStamp` value. This value is still a number of milliseconds, but with microsecond resolution, meaning the value now includes a decimal component. Additionally, instead of the value being relative to the epoch, the value is relative to `performance.timing.navigationStart`, i.e. the time at which the user navigated to the page. ([We’re working on getting this into the spec.](https://github.com/whatwg/dom/issues/23))
+Starting with Chromium 49, `timeStamp` is a `DOMHighResTimeStamp` value. This value is still a number of milliseconds, but with [a resolution of 5 microseconds](https://bugs.chromium.org/p/chromium/issues/detail?id=506723#c8), meaning the value now includes a decimal component. Additionally, instead of the value being relative to the epoch, the value is relative to `performance.timing.navigationStart`, i.e. the time at which the user navigated to the page. ([We’re working on getting this into the spec.](https://github.com/whatwg/dom/issues/23))
 
 To convert a `DOMHighResTimeStamp` value to an absolute number of milliseconds since the epoch (e.g., to get a value to pass to the `Date()` constructor), use `performance.timing.navigationStart + event.timeStamp`.
 


### PR DESCRIPTION
To prevent cache timing attacks, the resolution of DOMHighResTimeStamp was reduced to 5 microseconds.