### PR TITLE
don't lower the opacity of certain code fragments

### DIFF
--- a/src/styles/modules/highlight.scss
+++ b/src/styles/modules/highlight.scss
@@ -69,13 +69,3 @@
 .javascript .hljs-function {
 	color:#8959a8;
 	}
-
-.coffeescript .javascript,
-.javascript .xml,
-.tex .hljs-formula,
-.xml .javascript,
-.xml .vbscript,
-.xml .css,
-.xml .hljs-cdata {
-	opacity:0.5;
-	}


### PR DESCRIPTION
Right now when there's for example a code fragment that has javascript inside html, it's opacity is `0.5`, and that's less legible and looked a bit weird.

The removal of this style rule should make that no longer occur.