### PR TITLE
Remove mentions of Speed Dial API for extensions

### DIFF
--- a/src/_data/sidebar.yml
+++ b/src/_data/sidebar.yml
@@ -8,7 +8,6 @@
     - browser-actions
     - tab-window
     - context-menus
-    - speed-dial-manual
     - sidebar-action-manual
     - bookmarks
     - omnibox
@@ -48,6 +47,5 @@
     - apis
     - addons-api
     - sidebar-action-api
-    - speed-dial-api
     - manifest
     - getrootbyname

--- a/src/_extensions/acceptance-criteria.md
+++ b/src/_extensions/acceptance-criteria.md
@@ -56,7 +56,6 @@ The [browser action button](https://developer.chrome.com/extensions/browserActio
 - It must comply with the [Terms of Service](https://addons.opera.com/developer/terms/).
 - No external JavaScript is allowed. All JavaScript code must be contained in the extension. External APIs are ok.
 - It must not specifically point to, or be related to, gambling or betting services. 
-- Speed Dial extensions cannot just be a static picture linking to a website. They must provide valuable functionality, such as e.g. real-time info.
 - Extensions cannot replace Opera's default start page.
 - Extensions cannot just consist of a button linking to a website, or of a pop-up with some static links pointing to a website. Extensions must provide valuable functionality, such as e.g. a transformation applied on a page when a button is clicked, real-time info in a pop-up, etc.
 - Content inside pop-ups must be optimized for display in a pop-up. The content must match the pop-up's size, and vertical scrolling should only be used if really necessary. Avoid horizontal scrolling inside pop-ups.

--- a/src/_extensions/apis.md
+++ b/src/_extensions/apis.md
@@ -194,10 +194,6 @@ Below are is the list of extension APIs supported in Opera. Since most of these 
 	<td>Only in Opera</td>
 </tr>
 <tr>
-	<td><a href="/extensions/speed-dial-api/">Speed Dial</a></td>
-	<td>Only in Opera</td>
-</tr>
-<tr>
 	<td><a href="/extensions/sidebar-action-api/">sidebarAction</a></td>
 	<td>Only in Opera</td>
 </tr>

--- a/src/_extensions/architecture-overview.md
+++ b/src/_extensions/architecture-overview.md
@@ -15,7 +15,7 @@ Let’s dive deeper into the architecture and technical details of extensions in
 
 Opera supports the _NEX_ (short for **N**avigator **Ex**tension) file format for extensions. All the files and folders for an extension are packaged into a zip file with a special header and renamed as _.nex_. The NEX format supports a major portion of Chromium extensions, as well as APIs specific to Opera. The API docs section in the right sidebar gives you a good idea of the APIs Opera currently supports.
 
-The APIs from the Chromium project supported in NEX extensions (like tabs) can be called using `chrome.\*`, whereas the ones specific to Opera (like Speed Dial) will reside under the `opr.\*` object.
+The APIs from the Chromium project supported in NEX extensions (like tabs) can be called using `chrome.\*`, whereas the ones specific to Opera (like Sidebar Action) will reside under the `opr.\*` object.
 
 It is important to note that Opera will run extensions in Chromium’s CRX format too, as long as the extension uses the `chrome.\*` APIs that Opera supports.
 
@@ -37,11 +37,7 @@ Note: There can only be a maximum of 6 extensions installed at a time in the too
 
 As the name implies, they are extensions to the context menu of the page. You can bring up the context menu by either right-clicking an element in the page, or by using the appropriate shortcuts using your keyboard (varies according to your platform). We’ve created an article on [how to create context menu extensions](/extensions/context-menus/).
 
-### 3. Speed Dial extensions
-
-You can also create extensions for the Speed Dial in Opera. Keep in mind that to create Speed Dial extensions, you need to use the `opr` object, and will only run in an NEX file extension. Go ahead and check out [how to create Speed Dial extensions](/extensions/speed-dial-manual/).
-
-### 4. Extensions with no UI
+### 3. Extensions with no UI
 
 You can also create extensions which don’t have any UI component. If you are familiar with injected scripts in previous (Presto-based) versions of Opera, or with Greasemonkey scripts, then you get the idea.
 

--- a/src/_extensions/declare-permissions.md
+++ b/src/_extensions/declare-permissions.md
@@ -42,7 +42,6 @@ The following is an overview of the various permissions declarations possible in
 - `tabs`: Required if the extension uses the [chrome.tabs](https://developer.chrome.com/extensions/tabs) or [chrome.windows](https://developer.chrome.com/extensions/windows) API.
 - `webNavigation`: Gives your extension access to the [chrome.webNavigation](https://developer.chrome.com/extensions/webNavigation) API.
 - `webRequest`: Required if the extension uses the [chrome.webRequest](https://developer.chrome.com/extensions/webNavigation) API.
-- `speeddial`:  Required if the extension uses the [opr.speeddial](/extensions/speed-dial-api/) API.
 
 ## Optional permissions
 

--- a/src/_extensions/extension-samples.md
+++ b/src/_extensions/extension-samples.md
@@ -60,17 +60,6 @@ This is a repository of all the example extensions to help you get started with 
 - [Working with the context menu](/extensions/context-menus/)
 - [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus)
 
-## Speed Dial
-
-### Sample extension
-
-- [Sample Speed Dial extension](/extensions/extension-samples/speed-dial-center-content.nex)
-
-### Relevant reading
-
-- [Speed Dial extensions](/extensions/speed-dial-manual/)
-- [`opr.speeddial`](https://developer.chrome.com/extensions/speeddial)
-
 ## History API
 
 ### Sample extension


### PR DESCRIPTION
This API is deprecated and will be removed in Opera 60.